### PR TITLE
Apply name change for the ECC deployment pipelines

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 env:
-  REGISTRY_IMAGE: lontiplatform/martini-lonti-console-deploy-utility
+  REGISTRY_IMAGE: lontiplatform/martini-build-pipeline-lonti-managed-hosting
 
 jobs:
   deploy:

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'Martini Lonti Console Deploy Utility'
+name: 'Martini Build Pipeline Lonti Managed Hosting'
 description: 'Archives and deploys packages to Martini Essentials and Elastic server instances via the Lonti Console.'
 author: 'Lonti <support@lonti.com>'
 inputs:
@@ -19,7 +19,7 @@ inputs:
   description:
     description: >
       Deployment description
-      Default: `Deployed by Martini Lonti Console Deploy Utility`
+      Default: `Deployed by Martini Build Pipeline Lonti Managed Hosting`
   tag:
     description: >
       The version tag for this deployment

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "martini-lonti-console-deploy-utility",
+  "name": "martini-build-pipeline-lonti-managed-hosting",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "martini-lonti-console-deploy-utility",
+      "name": "martini-build-pipeline-lonti-managed-hosting",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "martini-lonti-console-deploy-utility",
+  "name": "martini-build-pipeline-lonti-managed-hosting",
   "version": "1.0.0",
   "description": "Archives and deploys packages to Martini Essentials and Elastic server instances via the Lonti Console.",
   "scripts": {
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/lontiplatform/martini-lonti-console-deploy-utility.git"
+    "url": "git+https://github.com/lontiplatform/martini-build-pipeline-lonti-managed-hosting.git"
   },
   "keywords": [
     "lonti",
@@ -23,9 +23,9 @@
   "author": "Lonti",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/lontiplatform/martini-lonti-console-deploy-utility/issues"
+    "url": "https://github.com/lontiplatform/martini-build-pipeline-lonti-managed-hosting/issues"
   },
-  "homepage": "https://github.com/lontiplatform/martini-lonti-console-deploy-utility#readme",
+  "homepage": "https://github.com/lontiplatform/martini-build-pipeline-lonti-managed-hosting#readme",
   "dependencies": {
     "@actions/core": "^1.11.1",
     "archiver": "^7.0.1",

--- a/src/input-helper.ts
+++ b/src/input-helper.ts
@@ -21,7 +21,7 @@ export function getInputs(): Inputs {
     description:
       core.getInput("description") ||
       process.env["DESCRIPTION"] ||
-      "Deployed by Martini Lonti Console Deploy Utility",
+      "Deployed by Martini Build Pipeline Lonti Managed Hosting",
     tag: core.getInput("tag") || process.env["TAG"] || "latest",
   };
 


### PR DESCRIPTION
Removed all references to martini-lonti-console-deploy-utility and changed to the new repository name.